### PR TITLE
Added separate map_new template to match GeoNode.

### DIFF
--- a/maploom/templates/maps/map_new.html
+++ b/maploom/templates/maps/map_new.html
@@ -1,0 +1,1 @@
+{% include "maps/map_view.html" %}


### PR DESCRIPTION
GeoNode now has a "map_new" template that differentiates from "map_view" generally. This basically creates an "alias" between map_view and map_new.

