### PR TITLE
Added editing template.

### DIFF
--- a/maploom/templates/maps/map_edit.html
+++ b/maploom/templates/maps/map_edit.html
@@ -1,0 +1,1 @@
+{% include "maps/map_view.html" %}


### PR DESCRIPTION
The previous version of the package did not override the map-eidting template.

This could cause a viewer other than maploom to be seen when starting a map-edit operation.